### PR TITLE
resolved the api-version warning when used in papermc server, and fix a mvn package phase warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.orig
 *.iml
 .idea/
+.DS_Store
 
 ### Maven ###
 target/

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.jdkVersion>1.8</project.jdkVersion>
+        <api.plugin.version>1.19</api.plugin.version>
     </properties>
 
     <profiles>
@@ -227,6 +228,7 @@
                             <artifact>*:*</artifact>
                             <excludes>
                                 <exclude>META-INF/maven/**</exclude>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: ${project.name}
 version: ${project.version}
 main: com.lenis0012.bukkit.loginsecurity.LoginSecurity
+api-version: ${api.plugin.version}
 author: lenis0012
 description: 'The #1 Auth plugin'
 softdepend: [ProtocolLib]


### PR DESCRIPTION
- ignore the MacOS .DS_Store file from the SVC
- resolve the warning when used as a papermc plugin: `Legacy plugin LoginSecurity v3.1.1 does not specify an api-version.`
- resolve a mvn package waring