### PR TITLE
Fix/230 exposed password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
             <version>1.14.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,23 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.14.6</version>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurity.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurity.java
@@ -90,7 +90,7 @@ public class LoginSecurity extends ModularPlugin {
 
         // Filter log
         org.apache.logging.log4j.core.Logger consoleLogger = (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
-        consoleLogger.addFilter(new LoggingFilter());
+        consoleLogger.addFilter(new LoggingFilter(config));
 
         // Register modules
         registry.registerModules(

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
@@ -18,7 +18,7 @@ public class LoggingFilter extends AbstractFilter {
 
     private final LoginSecurityConfig loginSecurityConfig;
 
-    private Result denyIfExposesPassword(String message) {
+    Result denyIfExposesPassword(String message) {
         if(message == null) {
             return Result.NEUTRAL;
         }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
@@ -31,10 +31,10 @@ public class LoggingFilter extends AbstractFilter {
         }
 
         if(loginSecurityConfig.isUseCommandShortcut()) {
-            final String loginCommandShortcut = loginSecurityConfig.getLoginCommandShortcut();
-            final String registerShortcut = loginSecurityConfig.getRegisterCommandShortcut();
-            if(message.startsWith(loginCommandShortcut)
-                    || message.contains("issued server command: " + loginCommandShortcut)
+            final String loginShortcut = loginSecurityConfig.getLoginCommandShortcut().trim() + ' ';
+            final String registerShortcut = loginSecurityConfig.getRegisterCommandShortcut().trim() + ' ';
+            if(message.startsWith(loginShortcut)
+                    || message.contains("issued server command: " + loginShortcut)
                     || message.startsWith(registerShortcut)
                     || message.contains("issued server command: " + registerShortcut)) {
                 return Result.DENY;

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
@@ -19,31 +19,26 @@ public class LoggingFilter extends AbstractFilter {
     private final LoginSecurityConfig loginSecurityConfig;
 
     Result denyIfExposesPassword(String message) {
-        if (message == null)
-			return Result.NEUTRAL;
+        if(message == null) {
+            return Result.NEUTRAL;
+        }
 
         message = message.toLowerCase();
-        final StringBuilder issuedBuilder = new StringBuilder("issued server command: ");
-        final int issuedStartingLength = issuedBuilder.length();
-        for(final String word : filteredWords) {
-			if (message.startsWith(word))
-				return Result.DENY;
-            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), word);
-            if (message.contains(issuedBuilder))
-				return Result.DENY;
+        for(String word : filteredWords) {
+            if(message.startsWith(word) || message.contains("issued server command: " + word)) {
+                return Result.DENY;
+            }
         }
 
         if(loginSecurityConfig.isUseCommandShortcut()) {
-            final String loginShortcut = loginSecurityConfig.getLoginCommandShortcut();
+            final String loginCommandShortcut = loginSecurityConfig.getLoginCommandShortcut();
             final String registerShortcut = loginSecurityConfig.getRegisterCommandShortcut();
-			if (message.startsWith(loginShortcut) || message.startsWith(registerShortcut))
-				return Result.DENY;
-            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), loginShortcut);
-            if (message.contains(issuedBuilder))
-				return Result.DENY;
-            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), registerShortcut);
-            if (message.contains(issuedBuilder))
+            if(message.startsWith(loginCommandShortcut)
+                    || message.contains("issued server command: " + loginCommandShortcut)
+                    || message.startsWith(registerShortcut)
+                    || message.contains("issued server command: " + registerShortcut)) {
                 return Result.DENY;
+            }
         }
 
         return Result.NEUTRAL;

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
@@ -19,26 +19,31 @@ public class LoggingFilter extends AbstractFilter {
     private final LoginSecurityConfig loginSecurityConfig;
 
     Result denyIfExposesPassword(String message) {
-        if(message == null) {
-            return Result.NEUTRAL;
-        }
+        if (message == null)
+			return Result.NEUTRAL;
 
         message = message.toLowerCase();
-        for(String word : filteredWords) {
-            if(message.startsWith(word) || message.contains("issued server command: " + word)) {
-                return Result.DENY;
-            }
+        final StringBuilder issuedBuilder = new StringBuilder("issued server command: ");
+        final int issuedStartingLength = issuedBuilder.length();
+        for(final String word : filteredWords) {
+			if (message.startsWith(word))
+				return Result.DENY;
+            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), word);
+            if (message.contains(issuedBuilder))
+				return Result.DENY;
         }
 
         if(loginSecurityConfig.isUseCommandShortcut()) {
-            final String loginCommandShortcut = loginSecurityConfig.getLoginCommandShortcut();
+            final String loginShortcut = loginSecurityConfig.getLoginCommandShortcut();
             final String registerShortcut = loginSecurityConfig.getRegisterCommandShortcut();
-            if(message.startsWith(loginCommandShortcut)
-                    || message.contains("issued server command: " + loginCommandShortcut)
-                    || message.startsWith(registerShortcut)
-                    || message.contains("issued server command: " + registerShortcut)) {
+			if (message.startsWith(loginShortcut) || message.startsWith(registerShortcut))
+				return Result.DENY;
+            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), loginShortcut);
+            if (message.contains(issuedBuilder))
+				return Result.DENY;
+            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), registerShortcut);
+            if (message.contains(issuedBuilder))
                 return Result.DENY;
-            }
         }
 
         return Result.NEUTRAL;

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
@@ -1,5 +1,7 @@
 package com.lenis0012.bukkit.loginsecurity.util;
 
+import com.lenis0012.bukkit.loginsecurity.LoginSecurityConfig;
+import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
@@ -10,10 +12,13 @@ import org.apache.logging.log4j.message.Message;
 import java.util.Arrays;
 import java.util.List;
 
+@RequiredArgsConstructor
 public class LoggingFilter extends AbstractFilter {
     private static final List<String> filteredWords = Arrays.asList("/register", "/login", "/changepassword", "/changepass");
 
-    private Result handle(String message) {
+    private final LoginSecurityConfig loginSecurityConfig;
+
+    private Result denyIfExposesPassword(String message) {
         if(message == null) {
             return Result.NEUTRAL;
         }
@@ -25,26 +30,37 @@ public class LoggingFilter extends AbstractFilter {
             }
         }
 
+        if(loginSecurityConfig.isUseCommandShortcut()) {
+            final String loginCommandShortcut = loginSecurityConfig.getLoginCommandShortcut();
+            final String registerShortcut = loginSecurityConfig.getRegisterCommandShortcut();
+            if(message.startsWith(loginCommandShortcut)
+                    || message.contains("issued server command: " + loginCommandShortcut)
+                    || message.startsWith(registerShortcut)
+                    || message.contains("issued server command: " + registerShortcut)) {
+                return Result.DENY;
+            }
+        }
+
         return Result.NEUTRAL;
     }
 
     @Override
     public Result filter(LogEvent event) {
-        return handle(event.getMessage().getFormattedMessage());
+        return denyIfExposesPassword(event.getMessage().getFormattedMessage());
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t) {
-        return handle(msg.getFormattedMessage());
+        return denyIfExposesPassword(msg.getFormattedMessage());
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
-        return handle(msg.toString());
+        return denyIfExposesPassword(msg.toString());
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String msg, Object... params) {
-        return handle(msg);
+        return denyIfExposesPassword(msg);
     }
 }

--- a/src/test/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilterTest.java
+++ b/src/test/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilterTest.java
@@ -1,0 +1,56 @@
+package com.lenis0012.bukkit.loginsecurity.util;
+
+import com.lenis0012.bukkit.loginsecurity.LoginSecurityConfig;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.core.Filter.Result;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.apache.logging.log4j.core.Filter.Result.DENY;
+import static org.apache.logging.log4j.core.Filter.Result.NEUTRAL;
+
+@RunWith(Parameterized.class)
+@RequiredArgsConstructor
+public class LoggingFilterTest {
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> parameters() {
+		LoginSecurityConfig shortcutsEnabled = Mockito.mock(LoginSecurityConfig.class);
+		Mockito.when(shortcutsEnabled.isUseCommandShortcut()).thenReturn(true);
+		Mockito.when(shortcutsEnabled.getLoginCommandShortcut()).thenReturn("/l");
+		Mockito.when(shortcutsEnabled.getRegisterCommandShortcut()).thenReturn("/reg");
+		LoginSecurityConfig shortcutsDisabled = Mockito.mock(LoginSecurityConfig.class);
+		Mockito.when(shortcutsEnabled.isUseCommandShortcut()).thenReturn(true);
+		return Arrays.asList(new Object[][] {
+				/* shortcuts enabled */
+				{new LoggingFilter(shortcutsEnabled), "/l qwerty", DENY},
+				{new LoggingFilter(shortcutsEnabled), "Hey, use /l to log in!", NEUTRAL},
+				{new LoggingFilter(shortcutsEnabled), "/reg qwerty", DENY},
+				{new LoggingFilter(shortcutsEnabled), "Hey, use /reg to register!", NEUTRAL},
+				{new LoggingFilter(shortcutsEnabled), "_voidpointer issued server command: /l qwerty", DENY},
+				{new LoggingFilter(shortcutsEnabled), "_voidpointer issued server command: /reg qwerty", DENY},
+				/* shortcuts disabled */
+				{new LoggingFilter(shortcutsDisabled), "/l qwerty", NEUTRAL},
+				{new LoggingFilter(shortcutsDisabled), "Hey, use /l to log in!", NEUTRAL},
+				{new LoggingFilter(shortcutsDisabled), "/reg qwerty", NEUTRAL},
+				{new LoggingFilter(shortcutsDisabled), "Hey, use /reg to register!", NEUTRAL},
+				{new LoggingFilter(shortcutsDisabled), "_voidpointer issued server command: /l qwerty", NEUTRAL},
+				{new LoggingFilter(shortcutsDisabled), "_voidpointer issued server command: /reg qwerty", NEUTRAL},
+		});
+	}
+
+	private final LoggingFilter loggingFilter;
+	private final String message;
+	private final Result expected;
+
+	@Test
+	public void testDenyIfExposesPassword() {
+		Assert.assertEquals(expected, loggingFilter.denyIfExposesPassword(message));
+	}
+}

--- a/src/test/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilterTest.java
+++ b/src/test/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilterTest.java
@@ -30,6 +30,7 @@ public class LoggingFilterTest {
 		return Arrays.asList(new Object[][] {
 				/* shortcuts enabled */
 				{new LoggingFilter(shortcutsEnabled), "/l qwerty", DENY},
+				{new LoggingFilter(shortcutsEnabled), "/luckperms help", NEUTRAL},
 				{new LoggingFilter(shortcutsEnabled), "Hey, use /l to log in!", NEUTRAL},
 				{new LoggingFilter(shortcutsEnabled), "/reg qwerty", DENY},
 				{new LoggingFilter(shortcutsEnabled), "Hey, use /reg to register!", NEUTRAL},
@@ -37,6 +38,7 @@ public class LoggingFilterTest {
 				{new LoggingFilter(shortcutsEnabled), "_voidpointer issued server command: /reg qwerty", DENY},
 				/* shortcuts disabled */
 				{new LoggingFilter(shortcutsDisabled), "/l qwerty", NEUTRAL},
+				{new LoggingFilter(shortcutsEnabled), "/luckperms help", NEUTRAL},
 				{new LoggingFilter(shortcutsDisabled), "Hey, use /l to log in!", NEUTRAL},
 				{new LoggingFilter(shortcutsDisabled), "/reg qwerty", NEUTRAL},
 				{new LoggingFilter(shortcutsDisabled), "Hey, use /reg to register!", NEUTRAL},


### PR DESCRIPTION
Fixes https://github.com/lenis0012/LoginSecurity/issues/230

I also thought using StringBuilder instead of concatenation would improve method's overall performance, but my JMH benchmark did not confirm this theory. I believe it can only improve RAM consumption, therefore it's a debatable topic: whether to keep the "optimization" changes or not, so I left the initial commit and reverted it in case someone would like to keep a version with better RAM utilization.

<details>
  <summary>The JMH benchmark that I used to test 2b11492b576a086e1a50c0d5f7ccb160c274f717 commit</summary>

```java
@State(Scope.Benchmark)
@Warmup(iterations=1, time=5)
@Measurement(iterations=3)
@Fork(1)
@BenchmarkMode(Mode.Throughput)
public class StringBuilderLogFilter {
    private static final List<String> filteredWords = Arrays.asList("/register", "/login", "/changepassword", "/changepass");
    private static final String message = "_voidpointer issued server command: /reg qwerasdf";

    @Param("/l")
    private String loginShortcut;
    @Param("/reg")
    private String registerShortcut;
    @Param("true")
    private boolean shortcutsEnabled;

    @Benchmark
    public void stringBuilder(final Blackhole bh) {
        final StringBuilder issuedBuilder = new StringBuilder("issued server command: ");
        final int issuedStartingLength = issuedBuilder.length();
        for (final String word : filteredWords) {
            if (message.startsWith(word)) {
                bh.consume("f");
                return;
            }
            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), word);
            if (message.contains(issuedBuilder)) {
                bh.consume("e");
                return;
            }
        }

        if (shortcutsEnabled) {
            if (message.startsWith(loginShortcut) || message.startsWith(registerShortcut)) {
                bh.consume("d");
                return;
            }
            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), loginShortcut);
            if (message.contains(issuedBuilder)) {
                bh.consume("c");
                return;
            }
            issuedBuilder.replace(issuedStartingLength, issuedBuilder.length(), registerShortcut);
            if (message.contains(issuedBuilder)) {
                bh.consume("b");
                return;
            }
        }

        bh.consume("a");
    }

    @Benchmark
    public void concatenation(final Blackhole bh) {
        for (final String word : filteredWords) {
            if (message.startsWith(word)) {
                bh.consume("f");
                return;
            }
            if (message.contains("issued server command: " + word)) {
                bh.consume("e");
                return;
            }
        }

        if (shortcutsEnabled) {
            if (message.startsWith(loginShortcut)
                    || message.startsWith(registerShortcut)
                    || message.contains("issued server command: " + loginShortcut)
                    || message.contains("issued server command: " + registerShortcut)) {
                bh.consume("d");
                return;
            }
        }
        bh.consume("a");
    }
}
```
</details>

<details>
  <summary>Benchmark results on my machine, OpenJDK 17.0.8</summary>

```
Benchmark                             (loginShortcut)  (registerShortcut)  (shortcutsEnabled)   Mode  Cnt        Score         Error  Units
StringBuilderLogFilter.concatenation               /l                /reg                true  thrpt    3  4839956.622 ± 1343710.522  ops/s
StringBuilderLogFilter.stringBuilder               /l                /reg                true  thrpt    3  3936585.734 ± 4270247.509  ops/s
```

</details>