### PR TITLE
Allow users to configure the allowed characters regular expression.

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
@@ -6,6 +6,7 @@ import com.lenis0012.pluginutils.config.mapping.ConfigHeader;
 import com.lenis0012.pluginutils.config.mapping.ConfigKey;
 import com.lenis0012.pluginutils.config.mapping.ConfigMapper;
 import lombok.Getter;
+import org.bukkit.Bukkit;
 
 @Getter
 @ConfigMapper(fileName = "config.yml", header = {
@@ -70,6 +71,8 @@ public class LoginSecurityConfig extends AbstractConfig {
     })
     @ConfigKey(path="username.filter-special-chars")
     private boolean filterSpecialChars = true;
+    @ConfigKey(path="username.filter-regex")
+    private String filterRegex = "[^a-zA-Z0-9_]";
     @ConfigKey(path="username.min-length")
     private int usernameMinLength = 3;
     @ConfigKey(path="username.max-length")

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/PlayerListener.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/PlayerListener.java
@@ -81,7 +81,7 @@ public class PlayerListener implements Listener {
         // Verify name
         final String name = event.getName();
         final LoginSecurityConfig config = LoginSecurity.getConfiguration();
-        if(config.isFilterSpecialChars() && !name.replaceAll("[^a-zA-Z0-9_]", "").equals(name)) {
+        if(config.isFilterSpecialChars() && !name.replaceAll(config.getFilterRegex(), "").equals(name)) {
             event.setLoginResult(Result.KICK_OTHER);
             event.setKickMessage("[LoginSecurity] " + translate(KICK_USERNAME_CHARS));
             return;


### PR DESCRIPTION
This is because floodgate append a dot (.) at the front of the player's name. So that if this regex remains the same no bedrock player can connect to  the server