### PR TITLE
Add anti-abuse banning mechanisms

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
@@ -61,6 +61,9 @@ public class LoginSecurityConfig extends AbstractConfig {
     })
     @ConfigKey(path = "join.hide-inventory-safe")
     private boolean hideInventory = false;
+    @ConfigHeader("When enabled, automatically bans IPs trying to join as already logged in users")
+    @ConfigKey(path = "join.ban.simultaneous-login")
+    private boolean banSimultaneous = false;
 
     /**
      * Username settings.

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
@@ -61,9 +61,16 @@ public class LoginSecurityConfig extends AbstractConfig {
     })
     @ConfigKey(path = "join.hide-inventory-safe")
     private boolean hideInventory = false;
+
+    /**
+     * Ban settings.
+     */
     @ConfigHeader("When enabled, automatically bans IPs trying to join as already logged in users")
     @ConfigKey(path = "join.ban.simultaneous-login")
     private boolean banSimultaneous = false;
+    @ConfigHeader("Notifies OPs in chat about LoginSecurity autobans")
+    @ConfigKey(path = "join.ban.notify-ops")
+    private boolean banNotifyOps = true;
 
     /**
      * Username settings.

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
@@ -71,6 +71,9 @@ public class LoginSecurityConfig extends AbstractConfig {
     @ConfigHeader("Notifies OPs in chat about LoginSecurity autobans")
     @ConfigKey(path = "join.ban.notify-ops")
     private boolean banNotifyOps = true;
+    @ConfigHeader("When enabled, automatically bans IPs which exceed 4 login tries")
+    @ConfigKey(path = "join.ban.bruteforce-attempt")
+    private boolean banBruteforceAttempt = false;
 
     /**
      * Username settings.

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/commands/CommandLogin.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/commands/CommandLogin.java
@@ -12,8 +12,10 @@ import com.lenis0012.bukkit.loginsecurity.session.action.ChangePassAction;
 import com.lenis0012.bukkit.loginsecurity.session.action.LoginAction;
 import com.lenis0012.bukkit.loginsecurity.storage.PlayerProfile;
 import com.lenis0012.bukkit.loginsecurity.util.MetaData;
+import com.lenis0012.bukkit.loginsecurity.util.OpNotifier;
 import com.lenis0012.pluginutils.command.Command;
 import org.bukkit.Bukkit;
+import org.bukkit.BanList;
 import org.bukkit.entity.Player;
 
 import java.util.logging.Level;
@@ -35,7 +37,18 @@ public class CommandLogin extends Command {
         LoginSecurityConfig config = LoginSecurity.getConfiguration();
         int tries = MetaData.incrementAndGet(player, "ls_login_tries");
         if(tries > config.getMaxLoginTries()) {
-            player.kickPlayer("[LoginSecurity] " + translate(LOGIN_TRIES_EXCEEDED).param("max", config.getMaxLoginTries()).toString());
+	    if(config.isBanBruteforceAttempt()) {
+		if(config.isBanNotifyOps()) {
+		    OpNotifier.notify("[LoginSecurity] " + player.getAddress().getHostString() +
+						" " + translate(BAN_BRUTEFORCE_ATTEMPT) + player.getName());
+		}
+		Bukkit.getBanList(BanList.Type.IP).addBan(player.getAddress().getHostString(), 
+					    translate(BAN_BRUTEFORCE_ATTEMPT).toString() + player.getName(),
+					    null, "LoginSecurity");
+                player.kickPlayer("[LoginSecurity] " + translate(BAN_BRUTEFORCE_ATTEMPT) + player.getName());
+	    } else {
+                player.kickPlayer("[LoginSecurity] " + translate(LOGIN_TRIES_EXCEEDED).param("max", config.getMaxLoginTries()).toString());
+	    }
             return;
         }
 

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/PlayerListener.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/PlayerListener.java
@@ -12,6 +12,7 @@ import com.lenis0012.bukkit.loginsecurity.storage.PlayerLocation;
 import com.lenis0012.bukkit.loginsecurity.storage.PlayerProfile;
 import com.lenis0012.bukkit.loginsecurity.util.MetaData;
 import com.lenis0012.bukkit.loginsecurity.util.UserIdMode;
+import com.lenis0012.bukkit.loginsecurity.util.OpNotifier;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -74,9 +75,18 @@ public class PlayerListener implements Listener {
                 PlayerSession session = LoginSecurity.getSessionManager().getPlayerSession(player);
                 if(session.isAuthorized()) {
 		    if(config.isBanSimultaneous()) {
-		    	Bukkit.getBanList(BanList.Type.IP).addBan(event.getAddress().getHostAddress(), translate(BAN_ALREADY_ONLINE).toString() + player.getName(), null, "LoginSecurity");
+		    	BanList banlist = Bukkit.getBanList(BanList.Type.IP);
+			if(!banlist.isBanned(event.getAddress().getHostAddress())) {
+		    	    banlist.addBan(event.getAddress().getHostAddress(), 
+					    translate(BAN_ALREADY_ONLINE).toString() + player.getName(),
+					    null, "LoginSecurity");
+			    if(config.isBanNotifyOps()) {
+			        OpNotifier.notify("[LoginSecurity] " + event.getAddress().getHostAddress() +
+						" " + translate(BAN_ALREADY_ONLINE) + player.getName());
+			    }
+			}
                     	event.setLoginResult(Result.KICK_BANNED);
-                    	event.setKickMessage("[LoginSecurity] " + translate(BAN_ALREADY_ONLINE));
+                    	event.setKickMessage("[LoginSecurity] " + translate(BAN_ALREADY_ONLINE) + player.getName());
 		    } else {
                     	event.setLoginResult(Result.KICK_OTHER);
                     	event.setKickMessage("[LoginSecurity] " + translate(KICK_ALREADY_ONLINE));

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/language/LanguageKeys.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/language/LanguageKeys.java
@@ -72,7 +72,11 @@ public enum LanguageKeys {
     KICK_USERNAME_CHARS("kickUsernameChars"),
     KICK_USERNAME_LENGTH("kickUsernameLength"),
     KICK_TIME_OUT("kickTimeOut"),
-    KICK_USERNAME_REGISTERED("kickUsernameRegistered");
+    KICK_USERNAME_REGISTERED("kickUsernameRegistered"),
+    /**
+     * Ban messages
+     */
+    BAN_ALREADY_ONLINE("banAlreadyOnline");
 
     private final String value;
 

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/language/LanguageKeys.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/language/LanguageKeys.java
@@ -76,7 +76,8 @@ public enum LanguageKeys {
     /**
      * Ban messages
      */
-    BAN_ALREADY_ONLINE("banAlreadyOnline");
+    BAN_ALREADY_ONLINE("banAlreadyOnline"),
+    BAN_BRUTEFORCE_ATTEMPT("banBruteforceAttempt");
 
     private final String value;
 

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/OpNotifier.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/OpNotifier.java
@@ -1,0 +1,17 @@
+package com.lenis0012.bukkit.loginsecurity.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class OpNotifier {
+    /**
+     * Send out a message to all server OPs
+     */
+    public static void notify(String message) {
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (p.isOp()) {
+                p.sendMessage(message);
+            }
+    	}
+    }
+}


### PR DESCRIPTION
Backstory:
Few days ago I setup a public 3rd party Minecraft server for me and my friends, but some port scanning griefer found it and wrecked havoc. After setting a whitelist and installing LoginSecurity, he didn't manage to get in, but I could see from the logs that he was trying his hardest - constantly trying commonly used names, changing IPs and so on. 
While I'm fairly happy with LoginSecurity, it doesn't seem to have any anti-abuse mechanisms, so I'm a bit worried that the guy might finally bruteforce his way in. Therefore, I decided to bite the bullet and try to implement some mechanisms myself.

This PR adds basic banning functionality in 2 flavors:
- auto banning IPs trying to login as already active and authorized accounts
- auto banning IPs exceeding login attempts

Both are off by default and are toggable in the config in the new ban section.
As an addition, there's another switch there too (notify-ops) which when enabled, sends a message to each server OP if a ban was to occur.
Side note, I know nothing about Java so this was written as my best approximation of "how this change really should look like", comments welcome!
